### PR TITLE
[Chore] Pin all dependency versions in requirements.txt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased — Issue #34: Pin all dependency versions] — 2026-02-20
+### Added
+- `requirements.txt` with pinned dependency versions for reproducible builds (#34)
+
 ## [Unreleased — Issue #30: Prometheus metrics endpoint] — 2026-02-20
 ### Added
 - Prometheus metrics endpoint (`GET /metrics`) via `prometheus-fastapi-instrumentator` (#30)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -61,7 +61,7 @@ Caching and codec work unlocks efficient streaming. System-level tuning reduces 
 - [ ] #31 Add structured JSON logging with per-request fields
 - [ ] #32 Add request queue depth limit with 503 early rejection
 - [x] #33 Migrate `@app.on_event` to FastAPI lifespan context manager
-- [ ] #34 Pin all dependency versions in `requirements.txt`
+- [x] #34 Pin all dependency versions in `requirements.txt`
 - [ ] #35 Convert to multi-stage Docker build
 - [x] #36 Remove dead `VoiceCloneRequest` model
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,22 @@
+# Pinned versions — update with care, test after any bump
+# Base image (pytorch/pytorch:2.5.1-cuda12.4-cudnn9-runtime) provides:
+#   torch==2.5.1, torchaudio==2.5.1, numpy, etc.
+
+# Model library
+qwen-tts>=0.1.0
+
+# Web framework
+fastapi==0.115.0
+uvicorn[standard]==0.32.0
+uvloop==0.21.0
+httptools==0.6.4
+python-multipart==0.0.12
+orjson==3.10.12
+
+# Audio processing
+soundfile==0.12.1
+pydub==0.25.1
+scipy==1.14.1
+
+# Model loading
+accelerate==1.1.1


### PR DESCRIPTION
## Summary
- Creates `requirements.txt` with pinned dependency versions for reproducible builds
- Dockerfile already references `requirements.txt` (from GPU persistence PR)
- Uses conservative/stable versions compatible with the pytorch:2.5.1-cuda12.4 base image

## Packages pinned
- qwen-tts>=0.1.0 (model library, loosely pinned since it's actively developed)
- fastapi==0.115.0, uvicorn==0.32.0, uvloop==0.21.0, httptools==0.6.4
- python-multipart==0.0.12, orjson==3.10.12
- soundfile==0.12.1, pydub==0.25.1, scipy==1.14.1
- accelerate==1.1.1

Closes #34