### PR TITLE
[Enhancement] Enable GPU persistence mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
-## [0.3.3] — 2026-02-20
+## [Unreleased — Issue #6: Enable GPU persistence mode] — 2026-02-20
+### Added
+- `docker-entrypoint.sh` — GPU persistence mode (`nvidia-smi -pm 1`) runs at container startup, eliminating 200-500ms GPU cold-start penalty (#6)
+
+### Changed
+- Dockerfile now uses ENTRYPOINT for GPU tuning before uvicorn starts
+
+## [Unreleased — Issue #5: Enable TF32 matmul mode] — 2026-02-20
 ### Changed
 - Enable TF32 matmul and cuDNN TF32 on Ampere+ GPUs for ~3x faster matrix operations (#5)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,10 +33,12 @@ RUN pip install --no-cache-dir \
     httptools \
     orjson
 
+COPY docker-entrypoint.sh /app/docker-entrypoint.sh
 COPY server.py /app/server.py
 
 EXPOSE 8000
 
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
 CMD ["uvicorn", "server:app", \
      "--host", "0.0.0.0", \
      "--port", "8000", \

--- a/LEARNING_LOG.md
+++ b/LEARNING_LOG.md
@@ -136,3 +136,12 @@ The improvement plan includes three layers of caching, and the ordering from hig
 The ordering matters for implementation priority. The output cache collapses the entire pipeline for repeated requests — inference, audio encoding, everything. One dict lookup replaces all of it. The voice prompt cache only saves preprocessing. The KV cache only saves part of inference. In terms of implementation effort, the output cache is roughly 20 lines of code. The voice prompt cache is similar. The KV cache is an open research question.
 
 For the phone call use case, the realistic expectation is that the output cache provides the majority of the benefit. IVR menus, hold messages, greeting phrases, and common system responses repeat constantly. A deployment serving 1000 calls per day with 20 unique system phrases would see cache hit rates above 90% after the first few calls. The per-request cost drops from 500ms of GPU inference to 1ms of memory lookup.
+
+---
+
+## Entry 0008 — GPU persistence mode and the entrypoint pattern
+**Date**: 2026-02-20
+**Type**: What just happened
+**Related**: #6
+
+We introduced `docker-entrypoint.sh` as the container's ENTRYPOINT, running GPU tuning commands before exec-ing into uvicorn. GPU settings like `nvidia-smi -pm 1` cannot be baked into the image at build time (no GPU during build). The entrypoint runs at container start when the GPU is available via NVIDIA runtime. The `|| echo` pattern ensures the service starts even without sufficient permissions.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,7 +24,7 @@ Before optimizing anything, we instrument. Then we remove the biggest bottleneck
 GPU tuning flags come first because they are low-risk and establish a faster baseline for benchmarking everything after. Inference optimizations build on that baseline. Audio quality improvements come last in the phase because they depend on a stable, fast inference path.
 
 - [x] #5 Enable TF32 matmul mode
-- [ ] #6 Enable GPU persistence mode
+- [x] #6 Enable GPU persistence mode
 - [ ] #7 Lock GPU clocks to max boost
 - [ ] #8 Switch `attn_implementation` to `flash_attention_2`
 - [ ] #9 Enable `torch.compile` on model forward pass

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# GPU tuning — best-effort, failures are non-fatal (may need --privileged)
+
+# Keep GPU driver initialized between workloads (eliminates 200-500ms cold-start)
+nvidia-smi -pm 1 2>/dev/null || echo "Warning: could not set GPU persistence mode"
+
+exec "$@"


### PR DESCRIPTION
Implements #6.

Introduces `docker-entrypoint.sh` as the container ENTRYPOINT that runs `nvidia-smi -pm 1` before starting uvicorn. GPU persistence mode keeps the NVIDIA driver initialized between workloads, eliminating 200-500ms cold-start penalty.

- `docker-entrypoint.sh`: runs GPU persistence mode, fails gracefully with warning
- `Dockerfile`: adds ENTRYPOINT before CMD
- Extension point for issue #7 (GPU clock locking)