### PR TITLE
[Enhancement] Lock GPU clocks to max boost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased — Issue #7: Lock GPU clocks to max boost] — 2026-02-20
+### Changed
+- `docker-entrypoint.sh` — lock GPU clocks to max boost frequency at container startup for consistent inference latency (#7)
+
 ## [Unreleased — Issue #6: Enable GPU persistence mode] — 2026-02-20
 ### Added
 - `docker-entrypoint.sh` — GPU persistence mode (`nvidia-smi -pm 1`) runs at container startup, eliminating 200-500ms GPU cold-start penalty (#6)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,7 +25,7 @@ GPU tuning flags come first because they are low-risk and establish a faster bas
 
 - [x] #5 Enable TF32 matmul mode
 - [x] #6 Enable GPU persistence mode
-- [ ] #7 Lock GPU clocks to max boost
+- [x] #7 Lock GPU clocks to max boost
 - [ ] #8 Switch `attn_implementation` to `flash_attention_2`
 - [ ] #9 Enable `torch.compile` on model forward pass
 - [ ] #10 Deepen GPU warmup with multi-length synthesis calls

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,4 +4,9 @@
 # Keep GPU driver initialized between workloads (eliminates 200-500ms cold-start)
 nvidia-smi -pm 1 2>/dev/null || echo "Warning: could not set GPU persistence mode"
 
+# Lock GPU clocks to max boost for consistent latency
+nvidia-smi --lock-gpu-clocks=0,9999 2>/dev/null || \
+  nvidia-smi -lgc 0,$(nvidia-smi --query-gpu=clocks.max.gr --format=csv,noheader,nounits 2>/dev/null | head -1) 2>/dev/null || \
+  echo "Warning: could not lock GPU clocks (may need privileged or specific GPU support)"
+
 exec "$@"


### PR DESCRIPTION
Implements #7.

Adds GPU clock locking (`nvidia-smi --lock-gpu-clocks`) to `docker-entrypoint.sh`. For short TTS inference bursts (400-600ms), GPU dynamic frequency scaling may not ramp to boost frequency before inference completes, causing latency variance. Clock locking eliminates this ramp-up time.

Two fallback strategies:
1. `nvidia-smi --lock-gpu-clocks=0,9999` (auto-max)
2. Query `clocks.max.gr` and lock explicitly
3. Warning if neither works (permissions or GPU support)