### PR TITLE
[Enhancement] Enable torch.compile on model forward pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased — Issue #9: Enable torch.compile] — 2026-02-20
+### Added
+- `torch.compile` on model forward pass with `reduce-overhead` mode for faster inference (#9)
+- `TORCH_COMPILE` env var (default: true) to opt-in/out of compilation
+
 ## [Unreleased — Issue #8: Switch to flash_attention_2] — 2026-02-20
 ### Changed
 - Switch attention implementation from `sdpa` to `flash_attention_2` with graceful fallback (#8)

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Environment variables in `compose.yaml`:
 | `MODEL_ID` | `Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice` | Hugging Face model ID |
 | `IDLE_TIMEOUT` | `120` | Seconds of inactivity before unloading model from GPU (0 = disabled) |
 | `REQUEST_TIMEOUT` | `300` | Maximum seconds per inference request |
+| `TORCH_COMPILE` | `true` | Enable torch.compile optimization (set to false to disable) |
 
 The model cache is persisted to `./models` via volume mount.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -27,7 +27,7 @@ GPU tuning flags come first because they are low-risk and establish a faster bas
 - [x] #6 Enable GPU persistence mode
 - [x] #7 Lock GPU clocks to max boost
 - [x] #8 Switch `attn_implementation` to `flash_attention_2`
-- [ ] #9 Enable `torch.compile` on model forward pass
+- [x] #9 Enable `torch.compile` on model forward pass
 - [ ] #10 Deepen GPU warmup with multi-length synthesis calls
 - [ ] #11 Add VAD silence trimming (strip leading/trailing silence)
 - [ ] #12 Add text normalization for numbers, currency, abbreviations

--- a/compose.yaml
+++ b/compose.yaml
@@ -11,6 +11,7 @@ services:
       - PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
       - REQUEST_TIMEOUT=300
       - IDLE_TIMEOUT=120
+      - TORCH_COMPILE=true
     volumes:
       - ./models:/root/.cache/huggingface
     shm_size: "1g"

--- a/server.py
+++ b/server.py
@@ -124,6 +124,15 @@ def _load_model_sync():
         attn_implementation=attn_impl,
     )
 
+    # Compile model for faster inference (PyTorch 2.0+)
+    if os.getenv("TORCH_COMPILE", "true").lower() == "true":
+        try:
+            import torch._dynamo  # noqa: F401
+            model.model = torch.compile(model.model, mode="reduce-overhead", fullgraph=False)
+            print("torch.compile enabled on model (mode=reduce-overhead)")
+        except Exception as e:
+            print(f"torch.compile not available or failed: {e}")
+
     # Warmup inference to trigger CUDA kernel caching
     if torch.cuda.is_available():
         print("Warming up GPU...")


### PR DESCRIPTION
Implements #9.

Applies `torch.compile(model.model, mode="reduce-overhead", fullgraph=False)` after model loading. Uses CUDA graphs for faster inference on repeated calls.

- `server.py`: torch.compile with try/except fallback, gated by `TORCH_COMPILE` env var
- `compose.yaml`: `TORCH_COMPILE=true` in service environment
- `README.md`: documented `TORCH_COMPILE` env var
- First inference after compilation is slower (tracing), subsequent calls are faster