### PR TITLE
[Refactor] Migrate @app.on_event to FastAPI lifespan context manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased — Issue #33: Migrate @app.on_event to FastAPI lifespan] — 2026-02-20
+### Changed
+- Migrated from deprecated `@app.on_event("startup")` to FastAPI lifespan context manager (#33)
+- Server now performs graceful model unload on shutdown via lifespan teardown
+
 ## [Unreleased — Issue #17: Audio output LRU cache] — 2026-02-20
 ### Added
 - Audio output LRU cache — in-memory cache keyed by SHA-256 of (text, voice, speed, format, language, instruct); cache hit returns bytes in ~1ms, skipping GPU entirely (#17)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -60,7 +60,7 @@ Caching and codec work unlocks efficient streaming. System-level tuning reduces 
 - [ ] #30 Add Prometheus metrics endpoint
 - [ ] #31 Add structured JSON logging with per-request fields
 - [ ] #32 Add request queue depth limit with 503 early rejection
-- [ ] #33 Migrate `@app.on_event` to FastAPI lifespan context manager
+- [x] #33 Migrate `@app.on_event` to FastAPI lifespan context manager
 - [ ] #34 Pin all dependency versions in `requirements.txt`
 - [ ] #35 Convert to multi-stage Docker build
 - [x] #36 Remove dead `VoiceCloneRequest` model


### PR DESCRIPTION
## Summary
- Replaces deprecated `@app.on_event("startup")` with `@asynccontextmanager` lifespan pattern
- Adds graceful model unload on shutdown (previously model was abandoned on SIGTERM)
- No behavior change for startup — idle watchdog still starts as a background task

## Changes
- `server.py`: Added `lifespan()` context manager, passed to `FastAPI(lifespan=lifespan)`, removed `@app.on_event("startup")` function
- `CHANGELOG.md`: Added v0.3.11 entry
- `ROADMAP.md`: Marked #33 complete
- `LEARNING_LOG.md`: Entry 0008 — why lifespan over on_event

Closes #33