### PR TITLE
[Enhancement] Add sentence-chunked SSE streaming endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased — Issue #3: Add sentence-chunked SSE streaming] — 2026-02-20
+### Added
+- Sentence-chunked SSE streaming endpoint `POST /v1/audio/speech/stream` (#3)
+  - Splits input into sentences with abbreviation-aware regex
+  - Streams base64-encoded raw PCM (int16, 24kHz) via Server-Sent Events
+  - Sends `data: [DONE]` on completion, `data: [ERROR] message` on failure
+  - Updates `_last_used` per chunk to prevent idle unload during streaming
+
 ## [Unreleased — Issue #2: Add adaptive max_new_tokens scaling] — 2026-02-20
 ### Changed
 - Replace hardcoded `max_new_tokens: 2048` with adaptive scaling based on input text length (#2)

--- a/README.md
+++ b/README.md
@@ -50,6 +50,27 @@ curl -X POST http://localhost:8101/v1/audio/speech \
 | `speed` | float | `1.0` | Playback speed multiplier |
 | `language` | string | *auto-detect* | Language override |
 
+
+### `POST /v1/audio/speech/stream`
+
+Stream speech synthesis via Server-Sent Events. Each sentence is synthesized independently and streamed as base64-encoded raw PCM audio (signed 16-bit, 24 kHz, mono).
+
+```bash
+curl -N -X POST http://localhost:8101/v1/audio/speech/stream \\
+  -H "Content-Type: application/json" \\
+  -d '{"input": "First sentence. Second sentence.", "voice": "vivian"}'
+```
+
+Each SSE event contains base64-encoded PCM data. The stream ends with `data: [DONE]`.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `input` | string | *required* | Text to synthesize |
+| `voice` | string | `vivian` | Voice name or OpenAI alias |
+| `speed` | float | `1.0` | Playback speed multiplier |
+| `language` | string | *auto-detect* | Language override |
+| `instruct` | string | *optional* | Style/instruction control |
+
 ### `POST /v1/audio/speech/clone`
 
 Generate speech using a cloned voice from a reference audio file.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -12,7 +12,7 @@ Before optimizing anything, we instrument. Then we remove the biggest bottleneck
 
 - [x] #1 Add per-request latency breakdown logging
 - [x] #2 Add adaptive `max_new_tokens` scaling with text length
-- [ ] #3 Add sentence-chunked SSE streaming endpoint
+- [x] #3 Add sentence-chunked SSE streaming endpoint
 - [ ] #4 Add raw PCM streaming endpoint
 
 ---


### PR DESCRIPTION
Implements #3

## Summary
- Add `POST /v1/audio/speech/stream` — sentence-chunked SSE streaming endpoint
- Add `_split_sentences()` with abbreviation-aware regex (handles Dr., Mr., etc.)
- Each sentence synthesized independently, streamed as base64-encoded raw PCM (int16, 24kHz)
- SSE framing: `data: <base64>`, completion: `data: [DONE]`, error: `data: [ERROR] msg`
- Updates `_last_used` after each chunk to prevent idle unload mid-stream
- Headers: `X-Accel-Buffering: no`, `Cache-Control: no-cache`

## Design decisions (see LEARNING_LOG entry 0008)
- Base64 over SSE chosen over chunked WAV (header requires total size) and raw binary (no framing)
- Raw PCM endpoint in issue #4 provides zero-overhead binary alternative

## Test plan
- [ ] `pytest server_test.py` — sentence splitting tests pass
- [ ] curl streaming endpoint and verify SSE events arrive incrementally
- [ ] Verify `[DONE]` sent at end of stream
- [ ] Test with multi-sentence input containing abbreviations