### PR TITLE
[Enhancement] Add eager model preload on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased — Issue #28: Preload model at startup] — 2026-02-20
+### Added
+- `PRELOAD_MODEL` env var — set to `true` to load model at startup instead of first request (#28)
+- Healthcheck `start_period` increased to 60s to accommodate preload
+
 ## [Unreleased — Issue #27: Always-on mode] — 2026-02-20
 ### Added
 - Always-on mode documentation — `IDLE_TIMEOUT=0` disables idle unload for dedicated GPU servers (#27)

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Environment variables in `compose.yaml`:
 | `VAD_TRIM` | `true` | Trim leading/trailing silence from generated audio |
 | `TEXT_NORMALIZE` | `true` | Expand numbers, currency, and abbreviations before synthesis |
 | `VOICE_CACHE_MAX` | `32` | LRU cache capacity for processed voice clone reference audio (0 = disabled) |
+| `PRELOAD_MODEL` | `false` | Load model at startup instead of on first request |
 
 The model cache is persisted to `./models` via volume mount.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -55,7 +55,7 @@ Caching and codec work unlocks efficient streaming. System-level tuning reduces 
 - [ ] #25 Enable HTTP/2 support
 - [ ] #26 Add Unix domain socket support for same-host clients
 - [x] #27 Add always-on mode (`IDLE_TIMEOUT=0` option, documented)
-- [ ] #28 Add eager model preload on startup (`PRELOAD_MODEL` env var)
+- [x] #28 Add eager model preload on startup (`PRELOAD_MODEL` env var)
 - [ ] #29 Add `ipc:host` to Docker compose for CUDA IPC
 - [ ] #30 Add Prometheus metrics endpoint
 - [ ] #31 Add structured JSON logging with per-request fields

--- a/compose.yaml
+++ b/compose.yaml
@@ -16,6 +16,7 @@ services:
       - VAD_TRIM=true
       - TEXT_NORMALIZE=true
       - VOICE_CACHE_MAX=32
+      - PRELOAD_MODEL=false     # true = load model at startup instead of first request
     volumes:
       - ./models:/root/.cache/huggingface
     shm_size: "1g"
@@ -31,4 +32,4 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 15s
+      start_period: 60s  # Increase if PRELOAD_MODEL=true (model load takes 10-15s)


### PR DESCRIPTION
## Summary
- Adds `PRELOAD_MODEL` env var (default `false`) to load model at startup via lifespan
- Eliminates cold-start latency on first request for production deployments
- Healthcheck `start_period` increased from 15s to 60s to accommodate preload

**Depends on**: #33 (lifespan, PR #49), #27 (always-on, PR #51)

Closes #28