### PR TITLE
[Enhancement] Add ipc:host to Docker compose for CUDA IPC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased — Issue #29: Add ipc:host for CUDA IPC] — 2026-02-20
+### Changed
+- Added `ipc: host` to Docker compose for CUDA IPC namespace sharing (#29)
+
 ## [Unreleased — Issue #35: Multi-stage Docker build] — 2026-02-20
 ### Changed
 - Dockerfile converted to multi-stage build — builder stage installs deps, runtime stage ships only packages and runtime libs (no git, no build tools) (#35)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -56,7 +56,7 @@ Caching and codec work unlocks efficient streaming. System-level tuning reduces 
 - [ ] #26 Add Unix domain socket support for same-host clients
 - [x] #27 Add always-on mode (`IDLE_TIMEOUT=0` option, documented)
 - [x] #28 Add eager model preload on startup (`PRELOAD_MODEL` env var)
-- [ ] #29 Add `ipc:host` to Docker compose for CUDA IPC
+- [x] #29 Add `ipc:host` to Docker compose for CUDA IPC
 - [x] #30 Add Prometheus metrics endpoint
 - [ ] #31 Add structured JSON logging with per-request fields
 - [ ] #32 Add request queue depth limit with 503 early rejection

--- a/compose.yaml
+++ b/compose.yaml
@@ -19,6 +19,7 @@ services:
       - PRELOAD_MODEL=false     # true = load model at startup instead of first request
     volumes:
       - ./models:/root/.cache/huggingface
+    ipc: host  # Share host IPC namespace — reduces CUDA IPC overhead for GPU tensor sharing
     shm_size: "1g"
     deploy:
       resources:


### PR DESCRIPTION
## Summary
- Adds `ipc: host` to the Docker compose service definition
- Shares host IPC namespace, reducing CUDA IPC overhead for GPU tensor sharing

Closes #29