### PR TITLE
[Enhancement] Add text normalization for numbers, currency, abbreviations

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -13,6 +13,7 @@ services:
       - IDLE_TIMEOUT=120
       - TORCH_COMPILE=true
       - VAD_TRIM=true
+      - TEXT_NORMALIZE=true
     volumes:
       - ./models:/root/.cache/huggingface
     shm_size: "1g"


### PR DESCRIPTION
Implements #12. Adds _normalize_text() for currency, abbreviations, and comma-separated numbers before synthesis. TEXT_NORMALIZE env var (default true) for opt-out.