### PR TITLE
feat: replace Unicode language heuristic with fasttext detection (#13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased — Issue #13: Replace Unicode language heuristic with fasttext detection] — 2026-02-20
+### Changed
+- `detect_language()` now uses `fasttext-langdetect` for accurate multi-language detection across 10 languages, falling back to Unicode character-range heuristic when fasttext is unavailable (#13)
+- Added `fasttext-langdetect` to Dockerfile dependencies
+- Added `_get_langdetect()` lazy-loader, `_detect_language_unicode()` fallback, and `_LANG_MAP` ISO-to-Qwen mapping
+
 ## [Unreleased — Issue #10: Multi-length GPU warmup] — 2026-02-20
 ### Changed
 - GPU warmup now runs 3 synthesis calls at different text lengths (5, 30, 90 chars) to pre-cache more CUDA kernel paths (#10)

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,8 @@ RUN pip install --no-cache-dir \
     uvloop \
     httptools \
     orjson \
-    flash-attn
+    flash-attn \
+    fasttext-langdetect
 
 COPY docker-entrypoint.sh /app/docker-entrypoint.sh
 COPY server.py /app/server.py

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -31,7 +31,7 @@ GPU tuning flags come first because they are low-risk and establish a faster bas
 - [x] #10 Deepen GPU warmup with multi-length synthesis calls
 - [ ] #11 Add VAD silence trimming (strip leading/trailing silence)
 - [ ] #12 Add text normalization for numbers, currency, abbreviations
-- [ ] #13 Replace Unicode language heuristic with fasttext detection
+- [x] #13 Replace Unicode language heuristic with fasttext detection
 - [ ] #14 Replace scipy speed adjustment with pitch-preserving pyrubberband
 - [ ] #15 Add voice prompt cache for `/clone` endpoint
 - [ ] #16 Pre-allocate GPU memory pool to reduce allocation jitter


### PR DESCRIPTION
## Summary
- Upgrades `detect_language()` to use `fasttext-langdetect` for accurate identification of 10 languages, including Latin-script European languages (French, German, Spanish, Italian, Portuguese, Russian) that the Unicode heuristic misclassified as English
- Falls back gracefully to the original Unicode character-range detection when `fasttext-langdetect` is not installed
- Lazy-loads the fasttext model on first call with a `False` sentinel to avoid retrying failed imports

## Changes
- `server.py`: New `_get_langdetect()`, `_detect_language_unicode()`, `_LANG_MAP`, and rewritten `detect_language()`
- `Dockerfile`: Added `fasttext-langdetect` to pip dependencies
- `server_test.py`: 22 tests covering fasttext path, Unicode fallback, error handling, and all 10 language mappings
- Living docs: CHANGELOG (v0.3.15), ROADMAP (checked off #13), LEARNING_LOG (Entry 0008)

## Test plan
- [x] 22 unit tests pass locally (pytest)
- [ ] Verify fasttext detection works in container with real text samples
- [ ] Verify graceful fallback when fasttext-langdetect is removed from Dockerfile

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)