### PR TITLE
feat: replace scipy speed adjustment with pitch-preserving pyrubberband (#14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased — Issue #14: Replace scipy speed adjustment with pyrubberband] — 2026-02-20
+### Changed
+- `_adjust_speed()` now uses `pyrubberband.time_stretch()` for pitch-preserving speed changes, falling back to `scipy.signal.resample` when pyrubberband is unavailable (#14)
+- Added `pyrubberband` to Dockerfile pip dependencies and `rubberband-cli` to apt dependencies
+
 ## [Unreleased — Issue #13: Replace Unicode language heuristic with fasttext detection] — 2026-02-20
 ### Changed
 - `detect_language()` now uses `fasttext-langdetect` for accurate multi-language detection across 10 languages, falling back to Unicode character-range heuristic when fasttext is unavailable (#13)

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ENV MKL_NUM_THREADS=2
 
 # Install system dependencies (sox needed by qwen-tts audio pipeline)
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    git libsndfile1 ffmpeg sox \
+    git libsndfile1 ffmpeg sox rubberband-cli \
     && rm -rf /var/lib/apt/lists/*
 
 # Install python dependencies
@@ -33,7 +33,8 @@ RUN pip install --no-cache-dir \
     httptools \
     orjson \
     flash-attn \
-    fasttext-langdetect
+    fasttext-langdetect \
+    pyrubberband
 
 COPY docker-entrypoint.sh /app/docker-entrypoint.sh
 COPY server.py /app/server.py

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -32,7 +32,7 @@ GPU tuning flags come first because they are low-risk and establish a faster bas
 - [ ] #11 Add VAD silence trimming (strip leading/trailing silence)
 - [ ] #12 Add text normalization for numbers, currency, abbreviations
 - [x] #13 Replace Unicode language heuristic with fasttext detection
-- [ ] #14 Replace scipy speed adjustment with pitch-preserving pyrubberband
+- [x] #14 Replace scipy speed adjustment with pitch-preserving pyrubberband
 - [ ] #15 Add voice prompt cache for `/clone` endpoint
 - [ ] #16 Pre-allocate GPU memory pool to reduce allocation jitter
 


### PR DESCRIPTION
## Summary
- Replaces `scipy.signal.resample()` with `pyrubberband.time_stretch()` for pitch-preserving speed adjustment (PSOLA algorithm)
- Eliminates chipmunk effect at speed>1.0 and deep voice artifact at speed<1.0
- Falls back gracefully to scipy resampling when pyrubberband/rubberband-cli are unavailable
- Extracted speed logic into reusable `_adjust_speed()` function

## Changes
- `server.py`: New `_adjust_speed()` function, replaced inline speed adjustment in `synthesize_speech`
- `Dockerfile`: Added `pyrubberband` to pip deps, `rubberband-cli` to apt deps
- `server_test.py`: 10 tests covering pyrubberband path, scipy fallback, edge cases
- Living docs: CHANGELOG (v0.3.16), ROADMAP (checked off #14), LEARNING_LOG (Entry 0008)

## Test plan
- [x] 10 unit tests pass locally (pytest)
- [ ] Verify speed=0.75, 1.0, 1.5 in container produce natural-sounding output
- [ ] Verify graceful fallback when pyrubberband is removed from Dockerfile

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)