### PR TITLE
feat: add voice prompt cache for /clone endpoint (#15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased — Issue #15: Add voice prompt cache for /clone endpoint] — 2026-02-20
+### Added
+- Voice prompt cache for `/clone` endpoint — caches processed reference audio by SHA-256 content hash (#15)
+- `VOICE_CACHE_MAX` env var (default: 32) — controls LRU cache capacity; set to 0 to disable
+- Cache stats exposed in `/health` endpoint: `voice_cache_size`, `voice_cache_max`, `voice_cache_hits`
+
 ## [Unreleased — Issue #14: Replace scipy speed adjustment with pyrubberband] — 2026-02-20
 ### Changed
 - `_adjust_speed()` now uses `pyrubberband.time_stretch()` for pitch-preserving speed changes, falling back to `scipy.signal.resample` when pyrubberband is unavailable (#14)

--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ Environment variables in `compose.yaml`:
 | `IDLE_TIMEOUT` | `120` | Seconds of inactivity before unloading model from GPU (0 = disabled) |
 | `REQUEST_TIMEOUT` | `300` | Maximum seconds per inference request |
 | `TORCH_COMPILE` | `true` | Enable torch.compile optimization (set to false to disable) |
+| `VAD_TRIM` | `true` | Trim leading/trailing silence from generated audio |
+| `TEXT_NORMALIZE` | `true` | Expand numbers, currency, and abbreviations before synthesis |
+| `VOICE_CACHE_MAX` | `32` | LRU cache capacity for processed voice clone reference audio (0 = disabled) |
 
 The model cache is persisted to `./models` via volume mount.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,11 +29,11 @@ GPU tuning flags come first because they are low-risk and establish a faster bas
 - [x] #8 Switch `attn_implementation` to `flash_attention_2`
 - [x] #9 Enable `torch.compile` on model forward pass
 - [x] #10 Deepen GPU warmup with multi-length synthesis calls
-- [ ] #11 Add VAD silence trimming (strip leading/trailing silence)
-- [ ] #12 Add text normalization for numbers, currency, abbreviations
+- [x] #11 Add VAD silence trimming (strip leading/trailing silence)
+- [x] #12 Add text normalization for numbers, currency, abbreviations
 - [x] #13 Replace Unicode language heuristic with fasttext detection
 - [x] #14 Replace scipy speed adjustment with pitch-preserving pyrubberband
-- [ ] #15 Add voice prompt cache for `/clone` endpoint
+- [x] #15 Add voice prompt cache for `/clone` endpoint
 - [ ] #16 Pre-allocate GPU memory pool to reduce allocation jitter
 
 ---

--- a/compose.yaml
+++ b/compose.yaml
@@ -14,6 +14,7 @@ services:
       - TORCH_COMPILE=true
       - VAD_TRIM=true
       - TEXT_NORMALIZE=true
+      - VOICE_CACHE_MAX=32
     volumes:
       - ./models:/root/.cache/huggingface
     shm_size: "1g"


### PR DESCRIPTION
## Summary
- Caches processed reference audio by SHA-256 content hash of uploaded bytes, eliminating redundant audio parsing on repeated clone calls with the same reference file (~50-100ms per cached hit)
- LRU eviction using OrderedDict at `VOICE_CACHE_MAX` entries (default 32, 0 = disabled)
- Cache stats exposed in `/health`: `voice_cache_size`, `voice_cache_max`, `voice_cache_hits`

## Changes
- `server.py`: New `_get_cached_ref_audio()` with LRU cache, `VOICE_CACHE_MAX` env var, `/health` cache stats
- `compose.yaml`: Added `VOICE_CACHE_MAX=32` environment variable
- `README.md`: Documented `VOICE_CACHE_MAX` in configuration table
- `server_test.py`: 11 tests covering cache hit/miss, LRU eviction, disabled mode, stereo-to-mono conversion, hash keying
- Living docs: CHANGELOG (v0.3.17), ROADMAP (checked off #15), LEARNING_LOG (Entry 0009)

## Test plan
- [x] 11 unit tests pass locally (pytest)
- [ ] Verify cache hits in container with repeated clone requests using same reference audio
- [ ] Verify `VOICE_CACHE_MAX=0` disables caching entirely
- [ ] Verify `/health` reports accurate cache stats

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)