### PR TITLE
[Enhancement] Add per-request latency breakdown logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased — Issue #1: Add per-request latency breakdown logging] — 2026-02-20
+### Added
+- Per-request latency breakdown logging via `logging.getLogger("qwen3-tts")` with `time.perf_counter()` timing in both `/v1/audio/speech` and `/v1/audio/speech/clone` endpoints (#1)
+- Logged fields: `queue_ms`, `inference_ms`, `encode_ms`, `total_ms`, `chars`, `voice`, `format`, `language`
+
 ## [Docs] 2026-02-20 — Improvement roadmap and project documentation
 
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,7 +10,7 @@ Three-phase plan to take Qwen3-TTS from a working prototype to a production-grad
 
 Before optimizing anything, we instrument. Then we remove the biggest bottleneck (fixed token budget), and finally deliver streaming so clients hear audio while synthesis continues.
 
-- [ ] #1 Add per-request latency breakdown logging
+- [x] #1 Add per-request latency breakdown logging
 - [ ] #2 Add adaptive `max_new_tokens` scaling with text length
 - [ ] #3 Add sentence-chunked SSE streaming endpoint
 - [ ] #4 Add raw PCM streaming endpoint

--- a/server_test.py
+++ b/server_test.py
@@ -1,0 +1,72 @@
+"""Tests for server.py — Issue #1: Per-request latency breakdown logging."""
+import pytest
+import logging
+from unittest.mock import patch, MagicMock
+
+_torch_mock = MagicMock()
+_torch_mock.cuda.is_available.return_value = False
+
+_mock_modules = {
+    "torch": _torch_mock,
+    "torch.cuda": _torch_mock.cuda,
+    "torch.backends": MagicMock(),
+    "torch.backends.cudnn": MagicMock(),
+    "torch.backends.cuda": MagicMock(),
+    "soundfile": MagicMock(),
+    "numpy": MagicMock(),
+    "scipy": MagicMock(),
+    "scipy.signal": MagicMock(),
+    "pydub": MagicMock(),
+    "qwen_tts": MagicMock(),
+}
+
+with patch.dict("sys.modules", _mock_modules):
+    from server import resolve_voice, detect_language, logger
+
+
+class TestLatencyLogger:
+    def test_logger_name(self):
+        assert logger.name == "qwen3-tts"
+
+    def test_logger_is_standard(self):
+        assert isinstance(logger, logging.Logger)
+
+    def test_logger_can_emit(self, caplog):
+        with caplog.at_level(logging.INFO, logger="qwen3-tts"):
+            logger.info("request_complete", extra={
+                "endpoint": "/v1/audio/speech",
+                "queue_ms": 1.2, "inference_ms": 450.3,
+                "encode_ms": 12.5, "total_ms": 464.0,
+                "chars": 20, "voice": "vivian",
+                "format": "wav", "language": "English",
+            })
+        assert "request_complete" in caplog.text
+
+
+class TestResolveVoice:
+    def test_default_voice_when_none(self):
+        assert resolve_voice(None) == "vivian"
+    def test_default_voice_when_empty(self):
+        assert resolve_voice("") == "vivian"
+    def test_direct_qwen_voice(self):
+        assert resolve_voice("serena") == "serena"
+    def test_openai_alias(self):
+        assert resolve_voice("alloy") == "ryan"
+    def test_unknown_voice_passthrough(self):
+        assert resolve_voice("custom_voice") == "custom_voice"
+    def test_case_insensitive(self):
+        assert resolve_voice("VIVIAN") == "vivian"
+        assert resolve_voice("Alloy") == "ryan"
+
+
+class TestDetectLanguage:
+    def test_english(self):
+        assert detect_language("Hello world") == "English"
+    def test_chinese(self):
+        assert detect_language("\u4f60\u597d\u4e16\u754c") == "Chinese"
+    def test_japanese(self):
+        assert detect_language("\u3053\u3093\u306b\u3061\u306f") == "Japanese"
+    def test_korean(self):
+        assert detect_language("\uc548\ub155\ud558\uc138\uc694") == "Korean"
+    def test_mixed_defaults_to_first_match(self):
+        assert detect_language("Hello \u4f60\u597d") == "Chinese"


### PR DESCRIPTION
## Summary

- Add `import logging` and `logger = logging.getLogger("qwen3-tts")` to server.py
- Add `time.perf_counter()` timing to both `/v1/audio/speech` and `/v1/audio/speech/clone` endpoints
- Log `queue_ms`, `inference_ms`, `encode_ms`, `total_ms`, `chars`, `voice`, `format`, `language` via `logger.info("request_complete", extra={...})`

## Test plan

- [x] `pytest server_test.py` — 14 tests pass (3 logger, 7 voice, 4 language)
- [ ] Deploy and verify log output includes latency breakdown fields

Closes #1