### PR TITLE
feat: expose temperature and top_p generation params (#83)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [Unreleased — Issue #83: expose temperature and top_p] — 2026-02-24
+
+### Added
+- Optional `temperature` and `top_p` fields on `TTSRequest` — passed through to `model.generate()` kwargs for controlling generation diversity
+- `temperature` and `top_p` Form parameters on `/v1/audio/speech/clone` endpoint
+- `temperature` and `top_p` JSON fields accepted on WebSocket `/v1/audio/speech/ws` endpoint
+- `_build_gen_kwargs()` helper to DRY up gen_kwargs construction across all synthesis endpoints
+
+### Changed
+- Replaced 4x repeated inline `gen_kwargs` dict construction with `_build_gen_kwargs()` calls in `/v1/audio/speech`, `/v1/audio/speech/stream`, `/v1/audio/speech/stream/pcm`
+- Fixed variable ordering bug in `/v1/audio/speech/clone` where `_adaptive_max_tokens(text)` was called before `text` was assigned
+
+---
+
 ## v0.6.0 — 2026-02-20
 
 Phase 3 Production Grade complete. All 36 roadmap issues implemented.

--- a/LEARNING_LOG.md
+++ b/LEARNING_LOG.md
@@ -4,6 +4,21 @@ Decisions, patterns, and lessons from building the Qwen3-TTS server. Each entry 
 
 ---
 
+## Entry 0023 — Exposing generation parameters: temperature and top_p
+**Date**: 2026-02-24
+**Type**: What just happened
+**Related**: Issue #83 — Expose temperature and top_p in TTSRequest
+
+The Qwen3-TTS model's `generate_custom_voice()` and `generate_voice_clone()` accept standard HuggingFace generation kwargs (`temperature`, `top_p`, etc.) but the server hardcoded only `max_new_tokens`. Clients had no way to control generation diversity.
+
+The fix adds two optional fields to `TTSRequest` (both default to `None`) and a `_build_gen_kwargs()` helper that conditionally includes them in the kwargs dict. When `None`, the key is omitted entirely — the model uses its own defaults, preserving exact backward compatibility. This matters because passing `temperature=None` explicitly to HuggingFace's `generate()` would be different from not passing it at all.
+
+The DRY improvement is incidental but valuable: four endpoints had identical `gen_kwargs = {"max_new_tokens": _adaptive_max_tokens(text)}` lines. The helper centralizes this pattern. Two endpoints (clone and WebSocket) build kwargs inline because they don't use `TTSRequest` — clone uses `Form` params and WebSocket uses raw JSON.
+
+A pre-existing bug was fixed in the clone endpoint: `_adaptive_max_tokens(text)` was called before `text = input.strip()`, using an undefined variable. The reordering to assign `text` first was necessary for correctness regardless of the temperature/top_p feature.
+
+---
+
 ## Entry 0012 — GPU memory pool pre-warming and CUDA allocator tuning
 **Date**: 2026-02-20
 **Type**: Why this design


### PR DESCRIPTION
## Summary
- Adds optional `temperature` and `top_p` fields to `TTSRequest` and all synthesis endpoints (REST, streaming, clone, WebSocket)
- Adds `_build_gen_kwargs()` helper to DRY up gen_kwargs construction across 4 endpoints
- Fixes pre-existing variable ordering bug in `/v1/audio/speech/clone` where `_adaptive_max_tokens(text)` was called before `text` was assigned

Closes #83

## Test plan
- [x] 6 new tests in `TestGenerationParams` class verify field acceptance, kwargs building, and backward compatibility
- [x] All 94 existing tests continue to pass (1 pre-existing numpy reimport failure unrelated)
- [ ] Integration test: POST `{"input": "hello", "temperature": 0.9, "top_p": 0.95}` to `/v1/audio/speech` and verify params reach model

🤖 Generated with [Claude Code](https://claude.com/claude-code)