### PR TITLE
feat: add quantization support INT8/FP8 (#86)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [Unreleased — Issue #86: quantization support] — 2026-02-24
+
+### Added
+- `QUANTIZE` env var — `int8` (bitsandbytes, ~50% VRAM reduction) or `fp8` (torchao, ~67% VRAM reduction) (#86)
+- `_resolve_quant_kwargs()` helper — returns `(dtype, load_kwargs)` for model loading (#86)
+- `bitsandbytes>=0.43.0` and `torchao>=0.5.0` added to `requirements.txt` (optional, install only when needed) (#86)
+
+### Changed
+- `_load_model_sync()` uses `_resolve_quant_kwargs()` instead of hardcoded `dtype=torch.bfloat16` (#86)
+
+---
+
 ## v0.7.0 — 2026-02-24
 
 Phase 4 Intelligence complete. Issues #81–#83 implemented.

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends git \
 COPY requirements.txt .
 RUN pip install --no-cache-dir --prefix=/install -r requirements.txt
 
+# Optional quantization — install only in GPU builds (they're large packages)
+RUN pip install --no-cache-dir --prefix=/install "bitsandbytes>=0.43.0" "torchao>=0.5.0" || true
+
 # Stage 2: runtime — lean image with only what's needed
 FROM pytorch/pytorch:2.5.1-cuda12.4-cudnn9-runtime
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,7 @@ scipy==1.14.1
 
 # Model loading
 accelerate==1.1.1
+
+# Optional quantization (required only when QUANTIZE=int8 or QUANTIZE=fp8)
+bitsandbytes>=0.43.0
+torchao>=0.5.0


### PR DESCRIPTION
Closes #86

## What
- `QUANTIZE` env var: `int8` (bitsandbytes) or `fp8` (torchao)
- `_resolve_quant_kwargs()` helper returns `(dtype, load_kwargs)` based on env var
- `_load_model_sync()` passes quant_kwargs to `from_pretrained()`
- `bitsandbytes>=0.43.0` + `torchao>=0.5.0` in `requirements.txt` (optional)
- Optional install step in Dockerfile with `|| true` fallback

## Why
Shared GPU environments benefit from VRAM reduction. INT8 cuts from ~2.4 GB to ~1.2 GB; FP8 cuts to ~0.8 GB. Default stays bfloat16 for maximum audio quality.

## Tests
`TestQuantization` class in `server_test.py` — 5 tests:
- Default (empty) returns bfloat16 with no extra kwargs
- `int8` returns float16 + `load_in_8bit=True`
- `int8` without bitsandbytes raises ImportError
- `fp8` returns bfloat16 + `quantization_config`
- Unknown value raises ValueError

Tests: 100 passed, 2 failed (pre-existing), 0 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)