### PR TITLE
feat: per-token streaming via rekuenkdr/Qwen3-TTS-streaming

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,17 @@ VOICE_CACHE_MAX=32
 # Expand numbers, currency symbols, and abbreviations before synthesis (true/false)
 TEXT_NORMALIZE=true
 
+# --- Streaming ---
+
+# Streaming mode: "sentence" (default, one chunk per sentence) or "token" (emit audio every N frames)
+STREAM_TYPE=sentence
+
+# Token-mode: emit audio every N codec frames (lower = more frequent, higher latency hiding)
+STREAM_EMIT_FRAMES=4
+
+# Token-mode: first-chunk emit interval (fewer frames = faster time-to-first-audio, 0 = disable two-phase)
+STREAM_FIRST_EMIT=3
+
 # --- Logging ---
 
 # Log output format: "json" (structured) or "text" (human-readable)

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,12 @@ RUN pip install --no-cache-dir "bitsandbytes>=0.43.0" || true
 # torchao for FP8 quantization (transformers 4.57+ expects this version's API)
 RUN pip install --no-cache-dir torchao || true
 
+# Streaming TTS fork — adds stream_generate_voice_clone() to qwen-tts
+# Installed AFTER flash-attn to preserve layer cache
+RUN pip install --no-cache-dir --no-deps \
+    "qwen-tts @ git+https://github.com/rekuenkdr/Qwen3-TTS-streaming.git" \
+    || true
+
 # Copy application
 COPY docker-entrypoint.sh /app/docker-entrypoint.sh
 COPY server.py /app/server.py


### PR DESCRIPTION
## Summary

Closes #110

- Add per-token streaming support using `rekuenkdr/Qwen3-TTS-streaming` fork for sub-400ms time-to-first-audio latency
- New env vars: `STREAM_TYPE` (sentence/token), `STREAM_EMIT_FRAMES`, `STREAM_FIRST_EMIT`
- Dual-mode streaming endpoints: token mode bypasses sentence splitting, streams audio chunks as they're generated
- Graceful fallback: if fork not installed, warns and falls back to sentence mode
- Docker layer placement preserves flash-attn cache (~2 min rebuild vs 45 min)

## Files changed

| File | Changes |
|------|---------|
| `Dockerfile` | +6 lines (streaming fork install layer after torchao) |
| `server.py` | +228 lines (env vars, validation, model load optimizations, streaming generator, async bridge, dual-mode endpoints) |
| `.env.example` | +11 lines (streaming config documentation) |

## Test plan

- [x] `python3 -c "import ast; ast.parse(open('server.py').read())"` — syntax check passes
- [ ] `docker compose build` — verify flash-attn layer is CACHED
- [ ] `docker compose up -d` — check logs for `streaming_optimizations_enabled` or fallback warning
- [ ] `STREAM_TYPE=sentence` — verify existing sentence-level streaming unchanged
- [ ] `STREAM_TYPE=token` — verify sub-400ms TTFB via `/v1/audio/speech/stream/pcm`
- [ ] Token streaming via WebSocket `/v1/audio/speech/ws`

🤖 Generated with [Claude Code](https://claude.com/claude-code)