### PR TITLE
fix: force-reinstall streaming TTS fork to prevent silent skip (#114)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.10.5 — 2026-03-02
+
+Fix silent streaming fork installation failure (#114).
+
+### Fixed
+- **Streaming fork silently skipped**: pip skipped `rekuenkdr/Qwen3-TTS-streaming` when `qwen-tts==0.1.1` was already installed (same package name + version) — added `--force-reinstall` to always override (#114)
+- **Install failures swallowed**: `|| true` on streaming fork install hid errors — removed so build fails loud if fork doesn't install (#114)
+
+---
+
 ## v0.10.4 — 2026-03-01
 
 Fix inference deadlock when streaming GPU thread stalls (#112).

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,11 +41,11 @@ RUN pip install --no-cache-dir "bitsandbytes>=0.43.0" || true
 # torchao for FP8 quantization (transformers 4.57+ expects this version's API)
 RUN pip install --no-cache-dir torchao || true
 
-# Streaming TTS fork — adds stream_generate_voice_clone() to qwen-tts
-# Installed AFTER flash-attn to preserve layer cache
-RUN pip install --no-cache-dir --no-deps \
-    "qwen-tts @ git+https://github.com/rekuenkdr/Qwen3-TTS-streaming.git" \
-    || true
+# Streaming TTS fork — MUST be last pip install to override qwen-tts==0.1.1
+# from requirements.txt. Adds stream_generate_voice_clone() method.
+# No || true — this is required, fail the build if it doesn't install.
+RUN pip install --no-cache-dir --no-deps --force-reinstall \
+    "qwen-tts @ git+https://github.com/rekuenkdr/Qwen3-TTS-streaming.git"
 
 # Copy application
 COPY docker-entrypoint.sh /app/docker-entrypoint.sh

--- a/LEARNING_LOG.md
+++ b/LEARNING_LOG.md
@@ -4,6 +4,19 @@ Decisions, patterns, and lessons from building the Qwen3-TTS server. Each entry 
 
 ---
 
+## Entry 0029 — Streaming fork: why --force-reinstall is required
+**Date**: 2026-03-02
+**Type**: What just happened
+**Related**: Issue #114 — Streaming fork install silently fails
+
+The streaming TTS fork (`rekuenkdr/Qwen3-TTS-streaming`) and the official `qwen-tts` package share the same name and version (`qwen-tts==0.1.1`). When pip sees the same version already installed from `requirements.txt`, it skips the fork installation entirely — even though the fork has different code (adds `stream_generate_voice_clone()`). The `|| true` on the Dockerfile install line swallowed this silently, so the build succeeded but the server fell back to sentence-level streaming without any build-time error.
+
+The fix: `--force-reinstall` tells pip to reinstall regardless of version match, and removing `|| true` ensures a genuine installation failure (network error, broken fork) stops the build. The fork install must remain the last pip step in the Dockerfile so it always overrides the base package.
+
+Lesson: when two packages share the same name+version, pip's version check is insufficient — `--force-reinstall` is the only reliable override. And `|| true` on a required dependency is a time bomb.
+
+---
+
 ## Entry 0028 — Inference deadlock: why streaming must go through the queue
 **Date**: 2026-03-01
 **Type**: What just happened

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # Base image (pytorch/pytorch:2.6.0-cuda12.4-cudnn9-runtime) provides:
 #   torch==2.6.0, torchaudio==2.6.0, numpy, Python 3.11
 
-# Model library
+# Model library — base package, overridden by streaming fork in Dockerfile
 qwen-tts==0.1.1
 
 # Web framework


### PR DESCRIPTION
## Summary
- Added `--force-reinstall` to streaming fork pip install in Dockerfile — pip was silently skipping the fork because `qwen-tts==0.1.1` was already installed from requirements.txt (same package name + version)
- Removed `|| true` so build fails loud if the fork doesn't install
- Updated requirements.txt comment to document the override relationship

Closes #114

## Test plan
- [x] `docker compose up -d --build` completes successfully
- [x] Health endpoint shows `has_streaming: true` and `STREAM_TYPE: token`
- [x] No "falling back to sentence" warning in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)